### PR TITLE
Allow custom login text

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ angular.module('app', [
 , require('fh-wfm-user-angular')({
   templates: {
     //Optional template for the login screen
+    //Note: This will be loaded from the angular template cache.
     login: 'mycustomlogintempalateid'
   }
 })

--- a/README.md
+++ b/README.md
@@ -7,10 +7,34 @@ This module is an AngularJS implementation of User functionality for the Raincat
 ```javascript
 angular.module('app', [
 ...
-, require('fh-wfm-user-angular')()
+, require('fh-wfm-user-angular')({
+  templates: {
+    //Optional template for the login screen
+    login: 'mycustomlogintempalateid'
+  }
+})
 ...
 ])
 ```
+
+## Templates
+
+### Login
+
+A custom html template can be passed in when rendering the `login` directive.
+
+This template has access to the Controller as `ctrl`.
+
+#### Login Controller Properties
+
+The Login Controller is assigned the following properties that are accessible to the custom template if required.
+
+| Property | Type | Description | Example |
+| ---- | ----------- | -------- | ------- |
+| login | function | Authenticates the user with a `username` and `password` parameters | `ctrl.login("someusername", "somepassowrd")` |
+| logout | function | Logs out the currently logged out user | `ctrl.logout()` |
+| hasSession | boolean | Identifies if the currently logged in user has a valid session | `ctrl.hasSession` |
+| loginErrorMessage | string | A message to display to the user if there is an error message | `ctrl.loginErrorMessage = "Invalid Credentials"` |
 
 ## Topics
 

--- a/lib/login/login-directive.js
+++ b/lib/login/login-directive.js
@@ -1,9 +1,11 @@
 var CONSTANTS = require('../constants');
 
-angular.module(CONSTANTS.USER_DIRECTIVE_MODULE).directive('login', function($templateCache) {
+angular.module(CONSTANTS.USER_DIRECTIVE_MODULE).directive('login', function($templateCache, USER_CONFIG) {
+
+  //Users can pass in their own template for login if required.
   return {
     restrict: 'E'
-    , template: $templateCache.get('wfm-template/login.tpl.html')
+    , template: $templateCache.get((USER_CONFIG.templates || {}).login || 'wfm-template/login.tpl.html')
     , controller: 'LoginCtrl'
     , controllerAs: 'ctrl'
     , replace: true

--- a/lib/user-ng.js
+++ b/lib/user-ng.js
@@ -3,6 +3,7 @@ var CONSTANTS = require('./constants');
 
 
 module.exports = function(config) {
+  config = config || {};
 
 
   angular.module(CONSTANTS.USER_MODULE_ID, [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-user-angular",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "An AngularJS module for viewing User details.",
   "main": "lib/user-ng.js",
   "repository": {


### PR DESCRIPTION
# Motivation

Developers may want to have their own template for the `login` directive.

This allows developers override the default directive.