### PR TITLE
Raincatch 747 add reload to user list

### DIFF
--- a/lib/worker-form/worker-form-controller.js
+++ b/lib/worker-form/worker-form-controller.js
@@ -56,7 +56,7 @@ function WorkerFormController($state, userMediatorService, $stateParams, $q) {
       }
 
       userOperation.then(function(createdUpdatedUser) {
-        $state.go('app.worker.detail', {workerId: createdUpdatedUser.id});
+        $state.go('app.worker.detail', {workerId: createdUpdatedUser.id}, {reload: true});
       });
     }
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-user-angular",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "An AngularJS module for viewing User details.",
   "main": "lib/user-ng.js",
   "repository": {


### PR DESCRIPTION
# What
The list of workers does not get updated when creating a new worker. List is only updated if page is refreshed. 

# How
Make sure that the state is reloaded/refreshed after creating a new worker by adding {reload: true} as a parameter to $state.go

# JIRA
https://issues.jboss.org/browse/RAINCATCH-747