### PR TITLE
[RAINCATCH-793] display group information upon group create or update

### DIFF
--- a/lib/group-form/group-form-controller.js
+++ b/lib/group-form/group-form-controller.js
@@ -32,8 +32,8 @@ function GroupFormController(userMediatorService, $stateParams, $q, $timeout, $s
     if (isValid) {
       var createUpdatePromise = groupId ? userMediatorService.updateGroup(self.model) : userMediatorService.createGroup(self.model);
 
-      createUpdatePromise.then(function() {
-        $state.go('app.group', {}, {reload: true});
+      createUpdatePromise.then(function(createdUpdatedGroup) {
+        $state.go('app.group.detail', {groupId: createdUpdatedGroup.id}, {reload: true});
       });
     }
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-user-angular",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "An AngularJS module for viewing User details.",
   "main": "lib/user-ng.js",
   "repository": {
@@ -19,7 +19,7 @@
   "author": "feedhenry-raincatcher@redhat.com",
   "license": "MIT",
   "dependencies": {
-    "fh-wfm-mediator": "0.3.1",
+    "fh-wfm-mediator": "0.3.4",
     "q": "1.4.1",
     "shortid": "^2.2.6"
   },


### PR DESCRIPTION
# What

- Ensure that group information is shown when a group is created or updated. 
- Bump mediator version to latest version.

# JIRA Ticket
https://issues.jboss.org/browse/RAINCATCH-793