### PR TITLE
[RAINCATCH-796] display error messages correctly upon user authentication

### DIFF
--- a/lib/login/login-controller.js
+++ b/lib/login/login-controller.js
@@ -32,7 +32,7 @@ function LoginCtrl($timeout, userMediatorService) {
         }, function(err) {
           $timeout(function() {
             self.loginMessages.error = true;
-            self.loginErrorMessage = err;
+            self.loginErrorMessage = err.toString();
           });
         });
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-user-angular",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "An AngularJS module for viewing User details.",
   "main": "lib/user-ng.js",
   "repository": {


### PR DESCRIPTION
# What
Display error messages correctly for both portal and mobile upon user authentication.

# JIRA Ticket
https://issues.jboss.org/browse/RAINCATCH-796